### PR TITLE
LaunchScreenのメモキチ画像の表示修正

### DIFF
--- a/univIP/univIP/LaunchScreen.storyboard
+++ b/univIP/univIP/LaunchScreen.storyboard
@@ -17,7 +17,7 @@
                         <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="k9B-W9-Cfq">
+                            <imageView clipsSubviews="YES" userInteractionEnabled="NO" contentMode="scaleAspectFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="memokichi" translatesAutoresizingMaskIntoConstraints="NO" id="k9B-W9-Cfq">
                                 <rect key="frame" x="119.5" y="360.5" width="175" height="175"/>
                                 <constraints>
                                     <constraint firstAttribute="width" constant="175" id="UQc-Dl-9ds"/>
@@ -51,6 +51,7 @@ GitHub: @tokudai0000</string>
         </scene>
     </scenes>
     <resources>
+        <image name="memokichi" width="283" height="283"/>
         <systemColor name="secondaryLabelColor">
             <color red="0.23529411764705882" green="0.23529411764705882" blue="0.2627450980392157" alpha="0.59999999999999998" colorSpace="custom" customColorSpace="sRGB"/>
         </systemColor>


### PR DESCRIPTION
## Issues
Closes #113 


## 概要
LaunchScreenの画像を表示するようにした

## 説明
マルチモジュール化に際してLaunchScreenのメモキチ画像が表示されていないバグが発生していた。

画像指定することにより解決


## キャプチャ
<img src="https://github.com/tokudai0000/univIP/assets/53287375/156b37a5-b955-4c8a-9cb8-92165614bc0b" width="40%">

## その他（懸念点や注意点）

