### PR TITLE
全エラーの解消

### DIFF
--- a/univIP/univIP.xcodeproj/project.pbxproj
+++ b/univIP/univIP.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1149,6 +1149,7 @@
 		};
 		1A53DB1B2A4850E00098DC94 /* Run Script(FirebaseCrashlytics) */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/univIP/univIP/Module/Home/Home.storyboard
+++ b/univIP/univIP/Module/Home/Home.storyboard
@@ -76,7 +76,7 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="HomeCollectionCell" id="hws-jS-6XF">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="menuCollectionCell" id="hws-jS-6XF">
                                                         <rect key="frame" x="0.0" y="0.0" width="128" height="128"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <collectionViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" insetsLayoutMarginsFromSafeArea="NO" id="2Tu-XB-8bP">

--- a/univIP/univIP/Module/Settings/Settings.storyboard
+++ b/univIP/univIP/Module/Settings/Settings.storyboard
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="Wwc-NT-iUu">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="21507" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
@@ -7,24 +7,6 @@
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
-        <!--Settings-->
-        <scene sceneID="bWd-KW-fEt">
-            <objects>
-                <navigationController id="boK-DK-3zY" userLabel="Settings" sceneMemberID="viewController">
-                    <tabBarItem key="tabBarItem" title="Settings" id="6pV-sJ-v8o"/>
-                    <simulatedTabBarMetrics key="simulatedBottomBarMetrics"/>
-                    <navigationBar key="navigationBar" contentMode="scaleToFill" id="LL8-OM-xtQ">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
-                        <autoresizingMask key="autoresizingMask"/>
-                    </navigationBar>
-                    <connections>
-                        <segue destination="Wwc-NT-iUu" kind="relationship" relationship="rootViewController" id="ybx-4c-AEr"/>
-                    </connections>
-                </navigationController>
-                <placeholder placeholderIdentifier="IBFirstResponder" id="yWy-g5-7Rm" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
-            </objects>
-            <point key="canvasLocation" x="713" y="1319"/>
-        </scene>
         <!--Settings-->
         <scene sceneID="oRR-xY-VwW">
             <objects>


### PR DESCRIPTION
## Issues
Closes #118 

## 概要
アラート解消

## 説明
[R.swift] Skipping 2 reuseIdentifiers because symbol 'homeCollectionCell' would be generated for all of these reuse identifiers: HomeCollectionCell, HomeCollectionCell
Run script build phase 'Run Script(FirebaseCrashlytics)' will be run during every build because it does not specify any outputs. To address this warning, either add output dependencies to the script phase, or configure it to run in every build by unchecking "Based on dependency analysis" in the script phase.
/Users/akidon/program/swift/univIP/univIP/univIP/AppIcon.xcassets: Accent color ‘AccentColor’ is not present in any asset catalogs.
/Users/akidon/program/swift/univIP/univIP/univIP/Module/Settings/Settings.storyboard “Settings“ is unreachable because it has no entry points, and no identifier for runtime access via -[UIStoryboard instantiateViewControllerWithIdentifier:].

のアラートをそれぞれまとめて解決

現時点でエラーは0

## キャプチャ


## その他（懸念点や注意点）

