### PR TITLE
アプリ内に規約バージョンを保持し、UDと比較する

### DIFF
--- a/univIP/univIP.xcodeproj/project.pbxproj
+++ b/univIP/univIP.xcodeproj/project.pbxproj
@@ -17,6 +17,7 @@
 		1A11C3DE2A952E5C00D95122 /* Acknowledgements.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 1A11C3DD2A952E5C00D95122 /* Acknowledgements.storyboard */; };
 		1A19730E27C4BCB200F36FE7 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A19730D27C4BCB200F36FE7 /* AppDelegate.swift */; };
 		1A20C4612A809A970063B5D6 /* HomeRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A20C4602A809A970063B5D6 /* HomeRouter.swift */; };
+		1A2237882AB6C58200A65301 /* AppConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A2237872AB6C58200A65301 /* AppConstants.swift */; };
 		1A239B5A2A84A90D0085BA46 /* PRRouter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A239B592A84A90D0085BA46 /* PRRouter.swift */; };
 		1A239B5C2A84A9C30085BA46 /* PRViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A239B5B2A84A9C30085BA46 /* PRViewModel.swift */; };
 		1A26A2612A77FB3C00BC6988 /* R.generated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A26A2602A77FB3C00BC6988 /* R.generated.swift */; };
@@ -244,6 +245,7 @@
 		1A19730D27C4BCB200F36FE7 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		1A1A4E102A09FE75003A343B /* AdItem.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AdItem.swift; sourceTree = "<group>"; };
 		1A20C4602A809A970063B5D6 /* HomeRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeRouter.swift; sourceTree = "<group>"; };
+		1A2237872AB6C58200A65301 /* AppConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppConstants.swift; sourceTree = "<group>"; };
 		1A239B592A84A90D0085BA46 /* PRRouter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRRouter.swift; sourceTree = "<group>"; };
 		1A239B5B2A84A9C30085BA46 /* PRViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PRViewModel.swift; sourceTree = "<group>"; };
 		1A26A2602A77FB3C00BC6988 /* R.generated.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = R.generated.swift; sourceTree = SOURCE_ROOT; };
@@ -452,6 +454,7 @@
 			isa = PBXGroup;
 			children = (
 				1A41EAE2272914CC0064CDB7 /* AKLibrary.swift */,
+				1A2237872AB6C58200A65301 /* AppConstants.swift */,
 				1A58F6732A84D9320025737A /* ItemsConstants.swift */,
 				1AFC67CC2732BFA80059A053 /* Url.swift */,
 				1A154F282A8C809900E6D3CB /* URLCheckers.swift */,
@@ -1311,6 +1314,7 @@
 				1AE816B62A833DF800B8DA64 /* NewsRouter.swift in Sources */,
 				1AC4BE8A2A7CE62700598EED /* AgreementViewModel.swift in Sources */,
 				1A58F67F2A861AFE0025737A /* SettingsRouter.swift in Sources */,
+				1A2237882AB6C58200A65301 /* AppConstants.swift in Sources */,
 				1A19730E27C4BCB200F36FE7 /* AppDelegate.swift in Sources */,
 				1AC4BE932A7DE91200598EED /* RootViewController.swift in Sources */,
 				1AED5D1A2A91A4840090B8DE /* HelpmessageAgreeViewController.swift in Sources */,

--- a/univIP/univIP/Common/AppConstants.swift
+++ b/univIP/univIP/Common/AppConstants.swift
@@ -1,0 +1,12 @@
+//
+//  AppConstants.swift
+//  univIP
+//
+//  Created by Akihiro Matsuyama on 2023/09/17.
+//
+
+enum AppConstants {
+    // 利用規約のバージョン
+    static let termsOfServiceVersion = "3.1.0"
+
+}

--- a/univIP/univIP/Module/Splash/SplashViewModel.swift
+++ b/univIP/univIP/Module/Splash/SplashViewModel.swift
@@ -63,9 +63,8 @@ final class SplashViewModel: BaseViewModel<SplashViewModel>, SplashViewModelInte
             return current != accepted
         }
 
-        func processTermVersion(response: CurrentTermVersionGetRequest.Response) {
-            state.termVersion.accept(response.currentTermVersion)
-            let current = response.currentTermVersion
+        func processTermVersion() {
+            let current = AppConstants.termsOfServiceVersion
             let accepted = dependency.acceptedTermVersionStoreUseCase.fetchAcceptedTermVersion()
             if isTermsVersionDifferent(current: current, accepted: accepted) {
                 // メインスレッドで実行(即AgreementViewの画面に行かないとWebログイン失敗もしくは成功の判定が先になり、表示されない可能性あり)
@@ -80,23 +79,9 @@ final class SplashViewModel: BaseViewModel<SplashViewModel>, SplashViewModelInte
             }
         }
 
-        func fetchAndHandleCurrentTermVersion() {
-            dependency.currentTermVersionAPI.getCurrentTermVersion()
-                .subscribe(on: ConcurrentDispatchQueueScheduler(qos: .background))
-                .subscribe(
-                    onSuccess: { response in
-                        processTermVersion(response: response)
-                    },
-                    onFailure: { error in
-                        AKLog(level: .ERROR, message: error)
-                    }
-                )
-                .disposed(by: disposeBag)
-        }
-
         input.viewDidLoad
             .subscribe { _ in
-                fetchAndHandleCurrentTermVersion()
+                processTermVersion()
             }
             .disposed(by: disposeBag)
 


### PR DESCRIPTION
## Issues
Closes #117 

## 概要
規約表示の不具合

## 説明
アプリ起動時に規約に同意しているのにも関わらず、規約同意画面が表示され不具合が発生していた。
原因としては、API成功時にUDから取得しているのでスレッドの関係などが調査しないといけないと思っているが、リリースを優先したいので、旧式の方法(デバイス内に最新の規約バージョンを記載し、UDの値と比較する)を復帰させた


## キャプチャ


## その他（懸念点や注意点）

