### PR TITLE
135-univBannerの修正

### DIFF
--- a/univIP/univIP/Module/Home/Banner/BannerScrollViewController.swift
+++ b/univIP/univIP/Module/Home/Banner/BannerScrollViewController.swift
@@ -162,41 +162,45 @@ class BannerScrollViewController: UIViewController {
     }
 
     func addUnivBannerPanels(items: [AdItem]) {
-        var prevBannerView: UnivBannerView?
+        var prevBannerView: UIImageView? // 1. オプショナルにする
+
         items.enumerated().forEach { index, item in
+            let bannerView = UIImageView() // 3. letにする
 
-            let bannerView = R.nib.univBannerView(withOwner: self)!
-            if let url = URL(string: item.imageUrlStr) {
-                bannerView.imageView.loadImage(from: url)
-                bannerView.imageView.contentMode = .scaleAspectFill
+            if let url = URL(string: item.imageUrlStr) { // 4. オプショナルを確認
+                bannerView.loadImage(from: url)
+                bannerView.contentMode = .scaleAspectFill
             }
-            bannerView.titleTextView.text = item.clientName
-            bannerView.discriptionTextView.text = item.imageDescription
 
-            // レイアウト
             bannerView.backgroundColor = .clear
             bannerView.translatesAutoresizingMaskIntoConstraints = false
             contentView.addSubview(bannerView)
+
             bannerView.topAnchor.constraint(equalTo: contentView.topAnchor).isActive = true
             bannerView.bottomAnchor.constraint(equalTo: contentView.bottomAnchor).isActive = true
+
             if index == 0 {
                 bannerView.leadingAnchor.constraint(equalTo: contentView.leadingAnchor).isActive = true
-            } else {
-                if let prevBanner = prevBannerView {
-                    bannerView.leadingAnchor.constraint(equalTo: prevBanner.trailingAnchor, constant: panelGap).isActive = true
-                }
+            } else if let prevBanner = prevBannerView { // 1. オプショナルを安全にアンラップ
+                bannerView.leadingAnchor.constraint(equalTo: prevBanner.trailingAnchor, constant: panelGap).isActive = true
             }
+
             bannerView.widthAnchor.constraint(equalToConstant: panelWidth).isActive = true
-            bannerView.imageView.layer.cornerRadius = 20
+
+            bannerView.layer.cornerRadius = 20 // 6. コーナーの半径
+            bannerView.clipsToBounds = true  // 6. クリッピングを有効に
+
             prevBannerView = bannerView
 
-            // バナーをタップしたときのイベント設定
             let gesture = UITapGestureRecognizer(target: self, action: #selector(didTapUnivBanner(gesture:)))
             gesture.numberOfTouchesRequired = 1
+            bannerView.isUserInteractionEnabled = true  // 5. インタラクションを有効に
             bannerView.tag = index
             bannerView.addGestureRecognizer(gesture)
         }
-        contentView.layoutSubviews()
+
+        // 2. layoutSubviews()の代わりに
+        contentView.setNeedsLayout()
     }
     
     @objc func didTapPrBanner(gesture: UITapGestureRecognizer) {


### PR DESCRIPTION
## Issues
Closes #135  

## 概要
大学教職員用の1/3のテキスト部分を削除

## 説明
広告サイズに関して、改めて考慮した結果、広告掲載主による自由なカスタマイズを可能にした方が、制作の負担も少なく、より柔軟な掲載が可能だと考えました。
この形式であれば、広告掲載主としても、掲載側としても、負担が軽減されると考えています。


## キャプチャ


## その他（懸念点や注意点）

