### PR TITLE
[143] webviewクラッシュ対応

### DIFF
--- a/univIP/univIP/Module/Web/WebViewController.swift
+++ b/univIP/univIP/Module/Web/WebViewController.swift
@@ -267,7 +267,9 @@ extension WebViewController: WKNavigationDelegate, WKUIDelegate {
                  for navigationAction: WKNavigationAction,
                  windowFeatures: WKWindowFeatures) -> WKWebView? {
         // 新しいタブで開くURLを取得し、読み込む
-        webView.load(navigationAction.request)
+        if navigationAction.targetFrame == nil {
+            webView.load(navigationAction.request)
+        }
         return nil
     }
 }


### PR DESCRIPTION
## Issues
Closes #143 


## 概要
webViewでクラッシュが起きていた

## 説明
どうやら、target="_blank"でクラッシュが起きていた

```
        if navigationAction.targetFrame == nil {
        }

```
を追加し解決できたはず

## キャプチャ


## その他（懸念点や注意点）

